### PR TITLE
Fix OpenAI Whisper API file format error by changing filename to audio.wav

### DIFF
--- a/listen.go
+++ b/listen.go
@@ -144,7 +144,7 @@ Listen:
 		client := openai.NewClientWithConfig(clientConfig)
 		req := openai.AudioRequest{
 			Model:    "whisper-1",
-			FilePath: "S16",
+			FilePath: "audio.wav",
 			Reader:   wavReader,
 			Language: "en",
 		}


### PR DESCRIPTION
Resolves file format recognition issue with OpenAI Whisper API mode. Changed hardcoded filename from "S16" (no extension) to "audio.wav" to ensure proper format detection by the API.